### PR TITLE
Fix Role Color Everywhere colors

### DIFF
--- a/src/main/_changes.scss
+++ b/src/main/_changes.scss
@@ -83,4 +83,17 @@
     .nameTag-m8r81H:not(.nameTag-2IFDfL) { 
         color: var(--header-secondary); 
     }
+    
+    // Role Color Everywhere
+    .rolecolor-colored-userpopout {
+        color: var(--color) !important;
+
+        .headerTagUsernameNoNickname-2_H881 {
+            color: inherit;
+        }
+
+        span:not([class]) {
+            opacity: 0.6;
+        }
+    }
 }


### PR DESCRIPTION
Show Role Color Everywhere role colors on user popout even when an activity is present.

![Role color on user popout](https://user-images.githubusercontent.com/56180050/113706100-dd1f0280-9710-11eb-9389-24bbc9922d79.png)

